### PR TITLE
(slightly) faster imgui rendering.

### DIFF
--- a/moderngl_window/integrations/imgui.py
+++ b/moderngl_window/integrations/imgui.py
@@ -1,6 +1,5 @@
 import ctypes
 
-import numpy as np
 import imgui
 import moderngl
 from imgui.integrations.opengl import BaseOpenGLRenderer
@@ -176,13 +175,13 @@ class ModernGLRenderer(BaseOpenGLRenderer):
         self._font_texture.use()
 
         for commands in draw_data.commands_lists:
-            # Create a numpy array mapping the vertex and index buffer data without copying it
-            vtx_ptr = ctypes.cast(commands.vtx_buffer_data, ctypes.POINTER(ctypes.c_byte))
-            idx_ptr = ctypes.cast(commands.idx_buffer_data, ctypes.POINTER(ctypes.c_byte))
-            vtx_data = np.ctypeslib.as_array(vtx_ptr, (commands.vtx_buffer_size * imgui.VERTEX_SIZE,))
-            idx_data = np.ctypeslib.as_array(idx_ptr, (commands.idx_buffer_size * imgui.INDEX_SIZE,))
-            self._vertex_buffer.write(vtx_data)
-            self._index_buffer.write(idx_data)
+            # Write the vertex and index buffer data without copying it
+            vtx_type = ctypes.c_byte * commands.vtx_buffer_size * imgui.VERTEX_SIZE
+            idx_type = ctypes.c_byte * commands.idx_buffer_size * imgui.INDEX_SIZE
+            vtx_arr = (vtx_type).from_address(commands.vtx_buffer_data)
+            idx_arr = (idx_type).from_address(commands.idx_buffer_data)
+            self._vertex_buffer.write(vtx_arr)
+            self._index_buffer.write(idx_arr)
 
             idx_pos = 0
             for command in commands.commands:


### PR DESCRIPTION
In the past, I've found `np.ctypeslib.as_array` to be a little slower than alternatives.
This eschews numpy in favor of a plain `ctypes` solution, using 'from_address' to avoid
inducing copies.

Running the `integrations/imgui.py` example for 2000 iterations via `line_profiler` (commit message had it wrong) shows a total runtime difference of 0.59 sec (master) vs 0.47 sec (branch) (or ~80% of the original runtime).

YMMV, but it seems generally a bit faster, and has the same phenotype as before.

Here are the times from `line_profiler`:

Master:
```
Timer unit: 1e-07 s                                                                                                                              

Total time: 0.591807 s
...
   179      7998     114712.0     14.3      1.9          for commands in draw_data.commands_lists:
   180                                                       # Create a numpy array mapping the vertex and index buffer data without copying it
   181      5998     348499.0     58.1      5.9              vtx_ptr = ctypes.cast(commands.vtx_buffer_data, ctypes.POINTER(ctypes.c_byte))
   182      5998     172397.0     28.7      2.9              idx_ptr = ctypes.cast(commands.idx_buffer_data, ctypes.POINTER(ctypes.c_byte))
   183      5998     948802.0    158.2     16.0              vtx_data = np.ctypeslib.as_array(vtx_ptr, (commands.vtx_buffer_size * imgui.VERTEX_SIZE,))
   184      5998     629407.0    104.9     10.6              idx_data = np.ctypeslib.as_array(idx_ptr, (commands.idx_buffer_size * imgui.INDEX_SIZE,))
   185      5998     316137.0     52.7      5.3              self._vertex_buffer.write(vtx_data)
   186      5998     203197.0     33.9      3.4              self._index_buffer.write(idx_data)
...
```

Branch:
```
Timer unit: 1e-07 s                                                                                                                              
                                                                                                                                                 
Total time: 0.470682 s  
...
   178      7998     134481.0     16.8      2.9          for commands in draw_data.commands_lists:                                               
   179                                                       # Write the vertex and index buffer data without copying it                         
   180      5998     204758.0     34.1      4.4              vtx_type = ctypes.c_byte * commands.vtx_buffer_size * imgui.VERTEX_SIZE             
   181      5998     138374.0     23.1      2.9              idx_type = ctypes.c_byte * commands.idx_buffer_size * imgui.INDEX_SIZE              
   182      5998     163487.0     27.3      3.5              vtx_arr = (vtx_type).from_address(commands.vtx_buffer_data)                         
   183      5998     133092.0     22.2      2.8              idx_arr = (idx_type).from_address(commands.idx_buffer_data)                         
   184      5998     273926.0     45.7      5.8              self._vertex_buffer.write(vtx_arr)                                                  
   185      5998     154152.0     25.7      3.3              self._index_buffer.write(idx_arr)
...
```