### PR TITLE
slightly more independent integrations.imgui.ModernGLRenderer

### DIFF
--- a/moderngl_window/integrations/imgui.py
+++ b/moderngl_window/integrations/imgui.py
@@ -112,13 +112,12 @@ class ModernGLRenderer(BaseOpenGLRenderer):
         self._index_buffer = None
         self._vao = None
         self.wnd = kwargs.get('wnd')
-        self.ctx = self.wnd.ctx
-
-        if not self.wnd:
-            raise ValueError('Missing window reference')
+        self.ctx = self.wnd.ctx if self.wnd and self.wnd.ctx else kwargs.get('ctx')
 
         if not self.ctx:
-            raise ValueError('Missing moderngl contex')
+            raise ValueError('Missing moderngl context')
+
+        assert isinstance(self.ctx, moderngl.context.Context)
 
         super().__init__()
 

--- a/moderngl_window/integrations/imgui.py
+++ b/moderngl_window/integrations/imgui.py
@@ -121,6 +121,9 @@ class ModernGLRenderer(BaseOpenGLRenderer):
 
         super().__init__()
 
+        if 'display_size' in kwargs:
+            self.io.display_size = kwargs.get('display_size')
+
     def refresh_font_texture(self):
         width, height, pixels = self.io.fonts.get_tex_data_as_rgba32()
 


### PR DESCRIPTION
I found integrations.imgui.ModernGLRenderer can be used without entire moderngl-window.
I thought ModernglWindowMixin should be responsible for moderngl-window depending things instead, and is also the original intention I believe.
