### PR TITLE
Fullscreen toggling in the window-config classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ docs/_build/
 
 # IDEs
 .vscode
+.idea
 
 # Environments
 .env

--- a/examples/fullscreen_switching.py
+++ b/examples/fullscreen_switching.py
@@ -1,0 +1,22 @@
+"""
+A example showing how you can switch between windowed and fullscreen
+"""
+import moderngl_window as mglw
+
+
+class FullscreenSwitching(mglw.WindowConfig):
+    # moderngl_window settings
+    title = "fullscreen-switching"
+
+    def render(self, time: float, frame_time: float) -> None:
+        pass
+
+    def key_event(self, key, action, modifiers):
+        if action == self.wnd.keys.ACTION_PRESS:
+            if key == self.wnd.keys.F11:
+                print('switching fs')
+                self.wnd.fullscreen = not self.wnd.fullscreen
+
+
+if __name__ == "__main__":
+    FullscreenSwitching.run()

--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -295,10 +295,18 @@ class BaseWindow:
         """bool: Window is resizable"""
         return self._resizable
 
+    @resizable.setter
+    def resizable(self, value: bool) -> None:
+        self._resizable = value
+
     @property
     def fullscreen(self) -> bool:
         """bool: Window is in fullscreen mode"""
         return self._fullscreen
+
+    @fullscreen.setter
+    def fullscreen(self, value: bool) -> None:
+        self._set_fullscreen(value)
 
     @property
     def config(self) -> 'WindowConfig':
@@ -612,6 +620,12 @@ class BaseWindow:
         """
         if self._resize_func:
             self._resize_func(width, height)
+
+    def _set_fullscreen(self, value: bool) -> None:
+        """
+        A library specific destroy method is required
+        """
+        raise NotImplementedError()
 
     def destroy(self) -> None:
         """

--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -307,6 +307,7 @@ class BaseWindow:
     @fullscreen.setter
     def fullscreen(self, value: bool) -> None:
         self._set_fullscreen(value)
+        self._fullscreen = value
 
     @property
     def config(self) -> 'WindowConfig':

--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -626,7 +626,7 @@ class BaseWindow:
         """
         A library specific destroy method is required
         """
-        raise NotImplementedError()
+        raise NotImplementedError(f"Toggling fullscreen is currently not supported by Window-type: {self.name}")
 
     def destroy(self) -> None:
         """

--- a/moderngl_window/context/glfw/window.py
+++ b/moderngl_window/context/glfw/window.py
@@ -111,8 +111,6 @@ class Window(BaseWindow):
         else:
             glfw.swap_interval(0)
 
-        self._fullscreen = value
-
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.

--- a/moderngl_window/context/pyglet/window.py
+++ b/moderngl_window/context/pyglet/window.py
@@ -75,6 +75,9 @@ class Window(BaseWindow):
         self._buffer_width, self._buffer_height = self._window.get_framebuffer_size()
         self.set_default_viewport()
 
+    def _set_fullscreen(self, value: bool) -> None:
+        self._window.set_fullscreen(value)
+
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.

--- a/moderngl_window/context/pyqt5/window.py
+++ b/moderngl_window/context/pyqt5/window.py
@@ -42,7 +42,7 @@ class Window(BaseWindow):
         # Configure multisampling if needed
         if self.samples > 1:
             gl.setSampleBuffers(True)
-            gl.setSamples(self.samples)
+            gl.setSamples(int(self.samples))
 
         # We need an application object, but we are bypassing the library's
         # internal event loop to avoid unnecessary work
@@ -73,7 +73,8 @@ class Window(BaseWindow):
 
         # Center the window on the screen if in window mode
         if not self.fullscreen:
-            self._widget.move(QtWidgets.QDesktopWidget().rect().center() - self._widget.rect().center())
+            center_window_position = self.position[0] - self.width/2, self.position[1] - self.height/2
+            self._widget.move(*center_window_position)
 
         # Needs to be set before show()
         self._widget.resizeGL = self.resize

--- a/moderngl_window/context/pyqt5/window.py
+++ b/moderngl_window/context/pyqt5/window.py
@@ -108,6 +108,12 @@ class Window(BaseWindow):
 
         self.set_default_viewport()
 
+    def _set_fullscreen(self, value: bool) -> None:
+        if value:
+            self._widget.showFullScreen()
+        else:
+            self._widget.showNormal()
+
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.

--- a/moderngl_window/context/pyside2/window.py
+++ b/moderngl_window/context/pyside2/window.py
@@ -114,7 +114,7 @@ class Window(BaseWindow):
             self._widget.showFullScreen()
         else:
             self._widget.showNormal()
-            
+
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.

--- a/moderngl_window/context/pyside2/window.py
+++ b/moderngl_window/context/pyside2/window.py
@@ -73,7 +73,8 @@ class Window(BaseWindow):
 
         # Center the window on the screen if in window mode
         if not self.fullscreen:
-            self._widget.move(QtWidgets.QDesktopWidget().rect().center() - self._widget.rect().center())
+            center_window_position = self.position[0] - self.width/2, self.position[1] - self.height/2
+            self._widget.move(*center_window_position)
 
         # Needs to be set before show()
         self._widget.resizeGL = self.resize
@@ -108,6 +109,12 @@ class Window(BaseWindow):
 
         self.set_default_viewport()
 
+    def _set_fullscreen(self, value: bool) -> None:
+        if value:
+            self._widget.showFullScreen()
+        else:
+            self._widget.showNormal()
+            
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.

--- a/moderngl_window/context/sdl2/window.py
+++ b/moderngl_window/context/sdl2/window.py
@@ -68,6 +68,9 @@ class Window(BaseWindow):
         self.init_mgl_context()
         self.set_default_viewport()
 
+    def _set_fullscreen(self, value: bool) -> None:
+        sdl2.SDL_SetWindowFullscreen(self._window, sdl2.SDL_WINDOW_FULLSCREEN_DESKTOP if value else 0)
+
     def _get_drawable_size(self):
         x = c_int()
         y = c_int()

--- a/moderngl_window/context/tk/window.py
+++ b/moderngl_window/context/tk/window.py
@@ -53,6 +53,9 @@ class Window(BaseWindow):
 
         self.set_default_viewport()
 
+    def _set_fullscreen(self, value: bool) -> None:
+        self._tk.attributes('-fullscreen', value)
+
     @property
     def size(self) -> Tuple[int, int]:
         """Tuple[int, int]: current window size.


### PR DESCRIPTION
Added fullscreen toggling to all window-config classes other than pygame. by setting the `wnd.fullscreen` variable to `True`/`False` the window will toggle between fullscreen and windowed. In some cases, windowed fullscreen may be used.
Also fixed a bug where the pyqt5 and pyside2 windows weren't getting centered correctly.