### PR TITLE
closing the window from inside `render`

### DIFF
--- a/moderngl_window/__init__.py
+++ b/moderngl_window/__init__.py
@@ -202,7 +202,8 @@ def run_window_config(config_cls: WindowConfig, timer=None, args=None) -> None:
         else:
             window.use()
         window.render(current_time, delta)
-        window.swap_buffers()
+        if not window.is_closing:
+            window.swap_buffers()
 
     _, duration = timer.stop()
     window.destroy()


### PR DESCRIPTION
When calling `self.wnd.close()` from inside `render`, the context would get destroyed, but moderngl-window would try to swap the buffers anyways causing an error. By first checking if the window is about to close we can avoid this. Another option would be to swap the buffers at the beginning of the frame instead of at the end, but this would mean you need to call render 2x to show the first frame.