### PR TITLE
Complete __str__ for KeyModifiers

### DIFF
--- a/moderngl_window/context/base/keys.py
+++ b/moderngl_window/context/base/keys.py
@@ -12,7 +12,7 @@ class KeyModifiers:
         return str(self)
 
     def __str__(self):
-        return "<KeyModifiers shift={} ctrl={} alt={}".format(
+        return "<KeyModifiers shift={} ctrl={} alt={}>".format(
             self.shift, self.ctrl, self.alt
         )
 


### PR DESCRIPTION
Hi!
I noticed the string representation of KeyModifiers is missing the final `>`.