### PR TITLE
Make windows classes a hardcoded list

### DIFF
--- a/moderngl_window/__init__.py
+++ b/moderngl_window/__init__.py
@@ -18,10 +18,8 @@ from moderngl_window.utils.module_loading import import_string
 
 __version__ = "2.3.0"
 
-IGNORE_DIRS = [
-    "__pycache__",
-    "base",
-]
+# Add new windows classes here to be recognized by the command line option --window
+WINDOW_CLASSES = ["glfw", "headless", "pygame2", "pyglet", "pyqt5", "pyside2", "sdl2", "tk"]
 
 OPTIONS_TRUE = ["yes", "on", "true", "t", "y", "1"]
 OPTIONS_FALSE = ["no", "off", "false", "f", "n", "0"]
@@ -126,20 +124,6 @@ def get_local_window_cls(window: str = None) -> Type[BaseWindow]:
     return get_window_cls("moderngl_window.context.{}.Window".format(window))
 
 
-def find_window_classes() -> List[str]:
-    """
-    Find available window packages
-
-    Returns:
-        A list of available window packages
-    """
-    return [
-        path.parts[-1]
-        for path in Path(__file__).parent.joinpath("context").iterdir()
-        if path.is_dir() and path.parts[-1] not in IGNORE_DIRS
-    ]
-
-
 def create_window_from_settings() -> BaseWindow:
     """
     Creates a window using configured values in :py:attr:`moderngl_window.conf.Settings.WINDOW`.
@@ -231,7 +215,7 @@ def create_parser():
     parser.add_argument(
         "-wnd",
         "--window",
-        choices=find_window_classes(),
+        choices=WINDOW_CLASSES,
         help="Name for the window type to use",
     )
     parser.add_argument(


### PR DESCRIPTION
- Creating `WINDOW_CLASSES` list containing the supported window types, used for command-line `--window` option. Notice that new window options must be added here, with the exact same name of the package.
- This should solve the problem explained in #131. The project works once compiled, tested on Windows 10 and Linux.

NOTE: I wasn't able to test the project using `tox` as stated in the README, got a few errors, tried later and now it just looks stuck, yet the tests work if triggered manually. Anyways there are no many changes in this PR and there shouldn't be any problems.