### PR TITLE
intercept close window button (ALT+F4)

### DIFF
--- a/examples/quit_confirm.py
+++ b/examples/quit_confirm.py
@@ -1,0 +1,42 @@
+import moderngl_window
+from moderngl_window.text.bitmapped import TextWriter2D
+
+class App(moderngl_window.WindowConfig):
+    title = "Text"
+    aspect_ratio = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.writer_quit = TextWriter2D()
+        self.writer_quit.text = "Quit?"
+
+        self.mode = 'normal'        # normal / quit
+        self.block_close = True
+
+        # *** Not working ***
+        self.wnd.close_func = self.close_event
+
+    def render(self, time, frame_time):
+        # *** it works ...
+        # self.wnd.close_func = self.close_event
+
+        if self.mode=='quit':
+            self.writer_quit.draw((240, 380), size=120)
+
+    def key_event(self, key, action, modifiers):
+        keys = self.wnd.keys
+        if self.mode=='quit':
+            if key==keys.Y:
+                self.block_close = False
+                self.wnd.close()
+            elif key==keys.N:
+                self.block_close = True
+                self.mode = 'normal'
+
+    def close_event(self,*args):
+        print('close event')
+        if self.block_close:
+            self.mode = 'quit'
+            self.wnd.is_closing = False
+
+App.run()

--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -662,9 +662,14 @@ class BaseWindow:
         """bool: Is the window about to close?"""
         return self._close
 
+    @is_closing.setter
+    def is_closing(self, value: bool):
+        self._close = value
+
+
     def close(self) -> None:
         """Signal for the window to close"""
-        self._close = True
+        self.is_closing = True
         self.close_func()
 
     def use(self):

--- a/moderngl_window/context/glfw/window.py
+++ b/moderngl_window/context/glfw/window.py
@@ -216,13 +216,17 @@ class Window(BaseWindow):
 
     def close(self) -> None:
         """Suggest to glfw the window should be closed soon"""
+        self.is_closing = True
         self._close_func()
-        glfw.set_window_should_close(self._window, True)
 
     @property
     def is_closing(self):
         """bool: Checks if the window is scheduled for closing"""
         return glfw.window_should_close(self._window)
+
+    @is_closing.setter
+    def is_closing(self, value: bool):
+        glfw.set_window_should_close(self._window, value)
 
     def swap_buffers(self):
         """Swap buffers, increment frame counter and pull events"""


### PR DESCRIPTION
This PR is NOT complete. This is only for GLFW.

Purpose:
 * When window is about to close by ALT+F4, user can have chance to interrupt termination
   (#143)

Changes:
 * setter for is_closing (as @einarf suggested)
   * user can interrupt window closing by "window.is_closing=False" in the "close callback" (window.close_func)
   * but in this case, user cannot close window by calling window.close(), because "close callback" is called in window.close() 
   * instead, user have to set "is_closing=True" to close window forcefully (not beautiful...)
   * no effect on users who don't use "close callback"


