### PR TITLE
Add an SSAO example

### DIFF
--- a/examples/base.py
+++ b/examples/base.py
@@ -33,7 +33,10 @@ class CameraWindow(mglw.WindowConfig):
 
 
 class OrbitCameraWindow(mglw.WindowConfig):
-    """Base class with built in 3D orbit camera support"""
+    """Base class with built in 3D orbit camera support
+
+    Move the mouse to orbit the camera around the view point.
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -58,6 +61,33 @@ class OrbitCameraWindow(mglw.WindowConfig):
     def mouse_scroll_event(self, x_offset: float, y_offset: float):
         if self.camera_enabled:
             self.camera.zoom_state(y_offset)
+
+    def resize(self, width: int, height: int):
+        self.camera.projection.update(aspect_ratio=self.wnd.aspect_ratio)
+
+
+class OrbitDragCameraWindow(mglw.WindowConfig):
+    """Base class with drag-based 3D orbit support
+
+    Click and drag with the left mouse button to orbit the camera around the view point.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.camera = OrbitCamera(aspect_ratio=self.wnd.aspect_ratio)
+
+    def key_event(self, key, action, modifiers):
+        keys = self.wnd.keys
+
+        if action == keys.ACTION_PRESS:
+            if key == keys.SPACE:
+                self.timer.toggle_pause()
+
+    def mouse_drag_event(self, x: int, y: int, dx, dy):
+        self.camera.rot_state(dx, dy)
+
+    def mouse_scroll_event(self, x_offset: float, y_offset: float):
+        self.camera.zoom_state(y_offset)
 
     def resize(self, width: int, height: int):
         self.camera.projection.update(aspect_ratio=self.wnd.aspect_ratio)

--- a/examples/resources/programs/ssao/blur.glsl
+++ b/examples/resources/programs/ssao/blur.glsl
@@ -1,0 +1,41 @@
+#version 330 core
+
+#if defined VERTEX_SHADER
+
+in vec3 in_position;
+in vec2 in_texcoord_0;
+
+out vec2 texcoord;
+
+void main() {
+    gl_Position = vec4(in_position, 1.0);
+    texcoord = in_texcoord_0;
+}
+
+#elif defined FRAGMENT_SHADER
+
+uniform sampler2D input_texture;
+
+in vec2 texcoord;
+
+layout(location=0) out float blurred_texture;
+
+void main() {
+    vec2 texel_size = 1.0 / vec2(textureSize(input_texture, 0));
+    float result = 0.0;
+    const int h = 2;
+    uint n_samples = 0u;
+    for (int x = -h; x <= h; ++x) {
+        for (int y = -h; y <= h; ++y) {
+            vec2 offset = vec2(float(x), float(y)) * texel_size;
+            float sample = texture(input_texture, texcoord + offset).x;
+            if (sample != 0.0) {
+                result += sample;
+                ++n_samples;
+            }
+        }
+    }
+    blurred_texture = result / float(n_samples);
+}
+
+#endif

--- a/examples/resources/programs/ssao/geometry.glsl
+++ b/examples/resources/programs/ssao/geometry.glsl
@@ -1,0 +1,35 @@
+#version 330
+
+#if defined VERTEX_SHADER
+
+uniform mat4 mvp;
+
+in vec3 in_position;
+in vec3 in_normal;
+
+out vec3 pos;
+out vec3 normal;
+
+void main() {
+    gl_Position = mvp * vec4(in_position, 1.0);;
+    pos = in_position;
+    normal = in_normal;
+}
+
+#elif defined FRAGMENT_SHADER
+
+uniform mat4 m_camera;
+
+in vec3 pos;
+in vec3 normal;
+
+layout(location=0) out float g_view_z;
+layout(location=1) out vec3 g_normal;
+
+void main() {
+    // Rotate into view space, and record the z component.
+    g_view_z = -(m_camera * vec4(pos, 1.0)).z;
+    g_normal = normalize(normal);
+}
+
+#endif

--- a/examples/resources/programs/ssao/shading.glsl
+++ b/examples/resources/programs/ssao/shading.glsl
@@ -32,6 +32,9 @@ void main() {
 
 uniform vec3 light_pos;
 uniform vec3 camera_pos;
+uniform vec3 base_color;
+uniform vec4 material_properties;
+uniform int render_mode;
 
 uniform sampler2D g_view_z;
 uniform sampler2D g_normal;
@@ -54,14 +57,26 @@ void main() {
     vec3 normal = texture(g_normal, texcoord).xyz;
 
     // Compute lighting.
-    float occlusion = texture(ssao_occlusion, texcoord).x;
+    float ambient_magnitude = material_properties.x;
+    float diffuse_magnitude = material_properties.y;
+    float specular_magnitude = material_properties.z;
+    float specular_exponent = material_properties.w;
+    float occlusion;
+    if (render_mode != 1) {
+        occlusion = texture(ssao_occlusion, texcoord).x;
+    } else {
+        occlusion = 1.0;
+    }
     vec3 light_dir = normalize(light_pos - position);
     vec3 reflection_dir = reflect(-light_dir, normal);
-    float ambient = 0.5 * occlusion;
-    float diffuse = 0.5 * max(dot(light_dir, normal), 0.0);
-    float specular = 0.4 * pow(max(dot(light_dir, normal), 0.0), 10.0);
+    float ambient = ambient_magnitude * occlusion;
+    float diffuse = diffuse_magnitude * max(dot(light_dir, normal), 0.0);
+    float specular = specular_magnitude * pow(max(dot(light_dir, normal), 0.0), specular_exponent);
     float luminosity = ambient + diffuse + specular;
-    vec3 color = luminosity * vec3(0.2, 0.2, 0.6);
+    vec3 color = luminosity * base_color;
+    if (render_mode == 2) {
+        color = vec3(occlusion);
+    }
     frag_color = vec4(color, 1.0);
 }
 

--- a/examples/resources/programs/ssao/shading.glsl
+++ b/examples/resources/programs/ssao/shading.glsl
@@ -1,0 +1,31 @@
+#version 330
+
+#if defined VERTEX_SHADER
+
+in vec3 in_position;
+in vec3 in_normal;
+
+uniform mat4 mvp;
+
+out vec3 pos;
+out vec3 normal;
+
+void main() {
+    gl_Position = mvp * vec4(in_position, 1.0);
+    pos = in_position;
+    normal = in_normal;
+}
+
+#elif defined FRAGMENT_SHADER
+
+in vec3 pos;
+in vec3 normal;
+
+out vec4 fragColor;
+
+void main() {
+    float l = dot(vec3(0.0, 1.0, 0.0), normalize(normal));
+    fragColor = vec4(0.5, 0.5, 0.5, 1.0) * (0.25 + abs(l) * 0.75);
+}
+
+#endif

--- a/examples/resources/programs/ssao/shading.glsl
+++ b/examples/resources/programs/ssao/shading.glsl
@@ -57,7 +57,7 @@ void main() {
     float occlusion = texture(ssao_occlusion, texcoord).x;
     vec3 light_dir = normalize(light_pos - position);
     vec3 reflection_dir = reflect(-light_dir, normal);
-    float ambient = 0.3;
+    float ambient = 0.3 * occlusion;
     float diffuse = 0.5 * max(dot(light_dir, normal), 0.0);
     float specular = 0.4 * pow(max(dot(light_dir, normal), 0.0), 10.0);
     float luminosity = ambient + diffuse + specular;

--- a/examples/resources/programs/ssao/shading.glsl
+++ b/examples/resources/programs/ssao/shading.glsl
@@ -57,12 +57,11 @@ void main() {
     float occlusion = texture(ssao_occlusion, texcoord).x;
     vec3 light_dir = normalize(light_pos - position);
     vec3 reflection_dir = reflect(-light_dir, normal);
-    float ambient = 0.3 * occlusion;
+    float ambient = 0.5 * occlusion;
     float diffuse = 0.5 * max(dot(light_dir, normal), 0.0);
     float specular = 0.4 * pow(max(dot(light_dir, normal), 0.0), 10.0);
     float luminosity = ambient + diffuse + specular;
     vec3 color = luminosity * vec3(0.2, 0.2, 0.6);
-    color = vec3(occlusion);
     frag_color = vec4(color, 1.0);
 }
 

--- a/examples/resources/programs/ssao/shading.glsl
+++ b/examples/resources/programs/ssao/shading.glsl
@@ -35,6 +35,7 @@ uniform vec3 camera_pos;
 
 uniform sampler2D g_view_z;
 uniform sampler2D g_normal;
+uniform sampler2D ssao_occlusion;
 
 in vec3 view_ray;
 in vec2 texcoord;
@@ -53,6 +54,7 @@ void main() {
     vec3 normal = texture(g_normal, texcoord).xyz;
 
     // Compute lighting.
+    float occlusion = texture(ssao_occlusion, texcoord).x;
     vec3 light_dir = normalize(light_pos - position);
     vec3 reflection_dir = reflect(-light_dir, normal);
     float ambient = 0.3;
@@ -60,6 +62,7 @@ void main() {
     float specular = 0.4 * pow(max(dot(light_dir, normal), 0.0), 10.0);
     float luminosity = ambient + diffuse + specular;
     vec3 color = luminosity * vec3(0.2, 0.2, 0.6);
+    color = vec3(occlusion);
     frag_color = vec4(color, 1.0);
 }
 

--- a/examples/resources/programs/ssao/ssao.glsl
+++ b/examples/resources/programs/ssao/ssao.glsl
@@ -1,0 +1,102 @@
+#version 330
+
+#if defined VERTEX_SHADER
+
+uniform mat4 m_camera_inverse;
+uniform mat4 m_projection_inverse;
+uniform vec3 v_camera_pos;
+
+in vec3 in_position;
+in vec2 in_texcoord_0;
+
+out vec3 view_ray;
+out vec2 texcoord;
+
+void main() {
+    gl_Position = vec4(in_position, 1.0);
+
+    // Convert in_position from clip space to view space.
+    vec4 pos = m_projection_inverse * vec4(in_position, 1.0);
+    // Normalize its z value.
+    pos.xy /= -pos.z;
+    pos.z = -1.0;
+    pos.w = 1.0;
+    // Convert to world space.
+    pos = m_camera_inverse * pos;
+    view_ray = pos.xyz - v_camera_pos;
+
+    texcoord = in_texcoord_0;
+}
+
+#elif defined FRAGMENT_SHADER
+
+const int n_samples = 64;
+
+uniform vec3 f_camera_pos;
+uniform mat4 mvp;
+uniform vec3 samples[n_samples];
+uniform bool randomize;
+uniform float z_offset;
+
+uniform sampler2D g_view_z;
+uniform sampler2D g_norm;
+uniform sampler2D noise;
+
+in vec3 view_ray;
+in vec2 texcoord;
+
+layout(location=0) out float occlusion;
+
+void main() {
+    // Ignore background fragments.
+    float f_view_z = texture(g_view_z, texcoord).x;
+    if (f_view_z == 0.0) {
+        discard;
+    }
+
+    // Load/compute the position and normal vectors (in world coordinates).
+    vec3 f_pos = f_camera_pos + f_view_z * view_ray;
+    vec3 f_norm = texture(g_norm, texcoord).xyz;
+
+    // Compute the rotation matrix that takes us from tangent space to world space.
+    // For now this is an arbitrary vector. If it's parallel to f_norm things will break.
+    vec3 random_vec = normalize(vec3(1.0, 0.17, 0.11));
+    vec3 tangent_x = normalize(random_vec - f_norm * dot(random_vec, f_norm));
+    vec3 tangent_y = cross(f_norm, tangent_x);
+    if (randomize) {
+        const int noise_size = 32;
+        vec2 noise_pos = (1.0 / float(noise_size)) * vec2(
+            float(mod(gl_FragCoord.x, noise_size)),
+            float(mod(gl_FragCoord.y, noise_size))
+        );
+        float random_angle = 6.2831853 * texture(noise, noise_pos).x;
+        float cosa = cos(random_angle);
+        float sina = sin(random_angle);
+        vec3 tangent_x_copy = tangent_x;
+        tangent_x = cosa * tangent_x + sina * tangent_y;
+        tangent_y = -sina * tangent_x_copy + cosa * tangent_y;
+    }
+    mat3 tan_to_world = mat3(tangent_x, tangent_y, f_norm);
+
+    // Measure occlusion.
+    occlusion = 0.0;
+    for (int i = 0; i < n_samples; ++i) {
+        // Compute the sample position in world coordinates.
+        vec3 sample_offset = tan_to_world * samples[i];
+        vec4 sample_pos = vec4(f_pos + sample_offset, 1.0);
+
+        // Convert to clip space, then scale the relevant coordinates to the range [0, 1].
+        sample_pos = mvp * sample_pos;
+        sample_pos.xyz /= sample_pos.w;
+        sample_pos.xy = 0.5 * sample_pos.xy + 0.5;
+
+        // Read the actual depth at the sample point.
+        float actual_view_z = texture(g_view_z, sample_pos.xy).x;
+
+        // If the actual depth is less than the depth of the sample point, the sample is occluded.
+        occlusion += (actual_view_z != 0.0 && actual_view_z + z_offset < f_view_z) ? 1.0 : 0.0;
+    }
+    occlusion = 1.0 - (1.0 / float(n_samples)) * occlusion;
+}
+
+#endif

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from pyrr import Matrix44
+
+import moderngl
+import moderngl_window
+from base import OrbitCameraWindow
+
+
+class SSAODemo(OrbitCameraWindow):
+    aspect_ratio = 16 / 9
+    resource_dir = Path(__file__).parent.resolve() / 'resources'
+    title = "SSAO"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.wnd.mouse_exclusivity = True
+
+        self.scene = self.load_scene('scenes/stanford_dragon.obj')
+
+        self.camera.projection.update(near=1.0, far=50.0)
+        self.camera.velocity = 7.0
+        self.camera.mouse_sensitivity = 0.3
+
+    def render(self, time: float, frametime: float):
+        self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
+
+        translation = Matrix44.from_translation((0, 0, -1.5))
+        rotation = Matrix44.from_eulers((0, 0, 0))
+        model_matrix = translation * rotation
+        camera_matrix = self.camera.matrix * model_matrix
+
+        self.scene.draw(
+            projection_matrix=self.camera.projection.matrix,
+            camera_matrix=camera_matrix,
+            time=time,
+        )
+
+
+if __name__ == '__main__':
+    moderngl_window.run_window_config(SSAODemo)

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -10,6 +10,12 @@ from moderngl_window.integrations.imgui import ModernglWindowRenderer
 
 
 class SSAODemo(OrbitCameraWindow):
+    """A demo of screen space ambient occlusion, based on https://learnopengl.com/Advanced-Lighting/SSAO
+
+    Runs best with a discrete GPU! Integrated GPUs can struggle a bit with the deferred rendering
+    pipeline.
+    """
+
     title = "SSAO"
     resource_dir = (Path(__file__) / '../resources').resolve()
 

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -5,11 +5,11 @@ import pyrr
 
 import moderngl
 import moderngl_window
-from base import OrbitCameraWindow
+from base import OrbitDragCameraWindow
 from moderngl_window.integrations.imgui import ModernglWindowRenderer
 
 
-class SSAODemo(OrbitCameraWindow):
+class SSAODemo(OrbitDragCameraWindow):
     """A demo of screen space ambient occlusion, based on https://learnopengl.com/Advanced-Lighting/SSAO
 
     Runs best with a discrete GPU! Integrated GPUs can struggle a bit with the deferred rendering
@@ -29,7 +29,7 @@ class SSAODemo(OrbitCameraWindow):
         self.camera.angle_y = -80.0
         self.camera.velocity = 7.0
         self.camera.target = (0.0, 0.0, 0.0)
-        self.camera.mouse_sensitivity = 0.3
+        self.camera.mouse_sensitivity = 1.0
         self.camera.zoom_sensitivity = 0.3
 
         self.render_modes = ["ADS + SSAO", "ADS (no SSAO)", "occlusion texture"]
@@ -200,11 +200,11 @@ class SSAODemo(OrbitCameraWindow):
 
     def mouse_position_event(self, x, y, dx, dy):
         self.imgui.mouse_position_event(x, y, dx, dy)
-        if not self.imgui.io.want_capture_mouse:
-            super().mouse_position_event(x, y, dx, dy)
 
     def mouse_drag_event(self, x: int, y: int, dx, dy):
         self.imgui.mouse_drag_event(x, y, dx, dy)
+        if not self.imgui.io.want_capture_mouse:
+            super().mouse_drag_event(x, y, dx, dy)
 
     def mouse_scroll_event(self, x_offset, y_offset):
         self.imgui.mouse_scroll_event(x_offset, y_offset)

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -17,18 +17,18 @@ class SSAODemo(OrbitCameraWindow):
 
         self.scene = self.load_scene('scenes/stanford_dragon.obj')
 
-        self.camera.projection.update(near=1.0, far=50.0)
+        self.camera.projection.update(near=0.1, far=50.0)
+        self.camera.radius = 3.0
+        self.camera.angle_x = 290.0
+        self.camera.angle_y = -80.0
         self.camera.velocity = 7.0
+        self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
 
     def render(self, time: float, frametime: float):
         self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
 
-        translation = Matrix44.from_translation((0, 0, -1.5))
-        rotation = Matrix44.from_eulers((0, 0, 0))
-        model_matrix = translation * rotation
-        camera_matrix = self.camera.matrix * model_matrix
-
+        camera_matrix = self.camera.matrix
         self.scene.draw(
             projection_matrix=self.camera.projection.matrix,
             camera_matrix=camera_matrix,

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -23,7 +23,7 @@ class SSAODemo(OrbitCameraWindow):
         self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
 
-        self.randomize_ssao_sample_orientations = True
+        self.randomize_ssao_sample_orientations = False
         self.ssao_z_offset = 0.0
 
         # Create the geometry framebuffer.

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -1,7 +1,7 @@
 import imgui
 import numpy as np
 from pathlib import Path
-from pyrr import Matrix44
+import pyrr
 
 import moderngl
 import moderngl_window
@@ -18,19 +18,20 @@ class SSAODemo(OrbitCameraWindow):
         #self.wnd.mouse_exclusivity = True
 
         self.camera.projection.update(near=0.1, far=50.0)
-        self.camera.radius = 3.0
+        self.camera.radius = 2.0
         self.camera.angle_x = 290.0
         self.camera.angle_y = -80.0
         self.camera.velocity = 7.0
         self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
+        self.camera.zoom_sensitivity = 0.3
 
         self.render_modes = ["ADS + SSAO", "ADS (no SSAO)", "occlusion texture"]
         self.render_mode = 0
         self.base_color = (0.2, 0.4, 0.8)
-        self.material_properties = [0.5, 0.5, 0.3, 25.0]
+        self.material_properties = [0.5, 0.5, 0.25, 25.0]
         self.ssao_z_offset = 0.0
-        self.ssao_blur = True
+        self.ssao_blur = False
 
         self.frame_time_decay_factor = 0.995
         self.average_frame_time = 0.01666
@@ -82,7 +83,7 @@ class SSAODemo(OrbitCameraWindow):
 
         # Generate SSAO samples (in tangent space coordinates, with z along the normal).
         self.n_ssao_samples = 64 # If you change this number, also change ssao.glsl.
-        self.ssao_std_dev = 0.5
+        self.ssao_std_dev = 0.1
         self.ssao_samples = np.random.normal(0.0, self.ssao_std_dev, (self.n_ssao_samples, 3))
         self.ssao_samples[:, 2] = np.abs(self.ssao_samples[:, 2])
         self.ssao_program["samples"].write(self.ssao_samples.ravel().astype('f4'))
@@ -173,7 +174,7 @@ class SSAODemo(OrbitCameraWindow):
         imgui.text(f"Frame time: {1000.0 * self.average_frame_time:.1f} ms")
         imgui.text(f"FPS: {1.0 / self.average_frame_time:.1f}")
         _, self.render_mode = imgui.combo("render mode", self.render_mode, self.render_modes)
-        _, self.ssao_z_offset = imgui.slider_float("SSAO z-offset", self.ssao_z_offset, 0.0, 1.0)
+        _, self.ssao_z_offset = imgui.slider_float("SSAO z-offset", self.ssao_z_offset, -0.3, 0.3)
         _, self.ssao_blur = imgui.checkbox("blur occlusion texture", self.ssao_blur)
 
         _, self.base_color = imgui.color_edit3(
@@ -185,7 +186,7 @@ class SSAODemo(OrbitCameraWindow):
         _, self.material_properties[0] = imgui.slider_float("ambient", self.material_properties[0], 0.0, 1.0)
         _, self.material_properties[1] = imgui.slider_float("diffuse", self.material_properties[1], 0.0, 1.0)
         _, self.material_properties[2] = imgui.slider_float("specular", self.material_properties[2], 0.0, 1.0)
-        _, self.material_properties[3] = imgui.slider_float("specular exponent", self.material_properties[3], 0.0, 100.0)
+        _, self.material_properties[3] = imgui.slider_float("specular exponent", self.material_properties[3], 1.0, 50.0)
 
         imgui.end()
         imgui.render()

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -25,6 +25,10 @@ class SSAODemo(OrbitCameraWindow):
         self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
 
+        self.render_modes = ["ADS + SSAO", "ADS (no SSAO)", "occlusion texture"]
+        self.render_mode = 0
+        self.base_color = (0.2, 0.4, 0.8)
+        self.material_properties = [0.5, 0.5, 0.3, 25.0]
         self.ssao_z_offset = 0.0
         self.ssao_blur = True
 
@@ -149,6 +153,9 @@ class SSAODemo(OrbitCameraWindow):
         self.shading_program["v_camera_pos"].value = camera_pos
         self.shading_program["camera_pos"].value = camera_pos
         self.shading_program["light_pos"].value = camera_pos
+        self.shading_program["base_color"].value = tuple(self.base_color)
+        self.shading_program["material_properties"].value = tuple(self.material_properties)
+        self.shading_program["render_mode"].value = self.render_mode
         self.g_view_z.use(location=0)
         self.g_normal.use(location=1)
         if self.ssao_blur:
@@ -165,9 +172,20 @@ class SSAODemo(OrbitCameraWindow):
         imgui.begin("Debug Panel", False)
         imgui.text(f"Frame time: {1000.0 * self.average_frame_time:.1f} ms")
         imgui.text(f"FPS: {1.0 / self.average_frame_time:.1f}")
-
+        _, self.render_mode = imgui.combo("render mode", self.render_mode, self.render_modes)
         _, self.ssao_z_offset = imgui.slider_float("SSAO z-offset", self.ssao_z_offset, 0.0, 1.0)
         _, self.ssao_blur = imgui.checkbox("blur occlusion texture", self.ssao_blur)
+
+        _, self.base_color = imgui.color_edit3(
+            "color",
+            self.base_color[0],
+            self.base_color[1],
+            self.base_color[2],
+        )
+        _, self.material_properties[0] = imgui.slider_float("ambient", self.material_properties[0], 0.0, 1.0)
+        _, self.material_properties[1] = imgui.slider_float("diffuse", self.material_properties[1], 0.0, 1.0)
+        _, self.material_properties[2] = imgui.slider_float("specular", self.material_properties[2], 0.0, 1.0)
+        _, self.material_properties[3] = imgui.slider_float("specular exponent", self.material_properties[3], 0.0, 100.0)
 
         imgui.end()
         imgui.render()

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -15,8 +15,6 @@ class SSAODemo(OrbitCameraWindow):
         super().__init__(**kwargs)
         self.wnd.mouse_exclusivity = True
 
-        self.scene = self.load_scene('scenes/stanford_dragon.obj')
-
         self.camera.projection.update(near=0.1, far=50.0)
         self.camera.radius = 3.0
         self.camera.angle_x = 290.0
@@ -25,15 +23,23 @@ class SSAODemo(OrbitCameraWindow):
         self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
 
-    def render(self, time: float, frametime: float):
-        self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
+        # Load a test shading program.
+        self.shading_program = self.load_program("programs/ssao/shading.glsl")
 
+        # Load the scene.
+        self.scene = self.load_scene('scenes/stanford_dragon.obj')
+        self.vao = self.scene.root_nodes[0].mesh.vao.instance(self.shading_program)
+
+    def render(self, time: float, frametime: float):
+        projection_matrix = self.camera.projection.matrix
         camera_matrix = self.camera.matrix
-        self.scene.draw(
-            projection_matrix=self.camera.projection.matrix,
-            camera_matrix=camera_matrix,
-            time=time,
-        )
+        mvp = projection_matrix * camera_matrix
+
+        self.ctx.enable_only(moderngl.DEPTH_TEST | moderngl.CULL_FACE)
+        self.ctx.screen.clear(1.0, 1.0, 1.0)
+        self.ctx.screen.use()
+        self.shading_program["mvp"].write(mvp.astype('f4'))
+        self.vao.render()
 
 
 if __name__ == '__main__':

--- a/examples/ssao.py
+++ b/examples/ssao.py
@@ -23,7 +23,6 @@ class SSAODemo(OrbitCameraWindow):
         self.camera.target = (0.0, 0.0, 0.0)
         self.camera.mouse_sensitivity = 0.3
 
-        self.randomize_ssao_sample_orientations = False
         self.ssao_z_offset = 0.0
 
         # Create the geometry framebuffer.
@@ -68,12 +67,12 @@ class SSAODemo(OrbitCameraWindow):
         self.ssao_samples[:, 2] = np.abs(self.ssao_samples[:, 2])
         self.ssao_program["samples"].write(self.ssao_samples.ravel().astype('f4'))
 
-        # Create random texture used to decorrelate SSAO samples.
-        rand_texture_size = 32
-        rand_texture_data = np.random.bytes(rand_texture_size * rand_texture_size)
+        # Create random vectors used to decorrelate SSAO samples.
+        rand_texture_size = 32 # If you change this number, also change ssao.glgl.
+        rand_texture_data = np.random.bytes(3 * rand_texture_size * rand_texture_size)
         self.random_texture = self.ctx.texture(
             (rand_texture_size, rand_texture_size),
-            1,
+            3,
             dtype="f1",
             data=rand_texture_data
         )
@@ -104,7 +103,6 @@ class SSAODemo(OrbitCameraWindow):
         self.ssao_program["v_camera_pos"].value = camera_pos
         self.ssao_program["f_camera_pos"].value = camera_pos
         self.ssao_program["mvp"].write(mvp.astype('f4'))
-        self.ssao_program["randomize"].value = self.randomize_ssao_sample_orientations
         self.ssao_program["z_offset"].value = self.ssao_z_offset
         self.g_view_z.use(location=0)
         self.g_normal.use(location=1)

--- a/moderngl_window/scene/camera.py
+++ b/moderngl_window/scene/camera.py
@@ -499,14 +499,15 @@ class OrbitCamera(Camera):
     @property
     def matrix(self) -> numpy.ndarray:
         """numpy.ndarray: The current view matrix for the camera"""
+        # Compute camera (eye) position, calculated from angles and radius.
+        position = (
+            cos(radians(self.angle_x)) * sin(radians(self.angle_y)) * self.radius + self.target[0],
+            cos(radians(self.angle_y)) * self.radius + self.target[1],
+            sin(radians(self.angle_x)) * sin(radians(self.angle_y)) * self.radius + self.target[2],
+        )
+        self.set_position(*position)
         return Matrix44.look_at(
-            (
-                cos(radians(self.angle_x)) * sin(radians(self.angle_y)) * self.radius
-                + self.target[0],
-                cos(radians(self.angle_y)) * self.radius + self.target[1],
-                sin(radians(self.angle_x)) * sin(radians(self.angle_y)) * self.radius
-                + self.target[2],
-            ),  # camera (eye) position, calculated from angles and radius
+            position,
             self.target,  # what to look at
             self.up,  # camera up direction (change for rolling the camera)
             dtype="f4",


### PR DESCRIPTION
I've run it on Mac and Linux. It's a little slow when run with an integrated GPU.

I made one change to `OrbitCamera`. Previously, its `matrix` property computed its position (from angles and radius) and didn't save it. It's a bit of a hack, but now it calls `self.set_position` so that `self.position` reflects the last time the matrix was computed. I grepped for "OrbitCamera" and it looks like the only other place it's used is in [examples/orbit_camera.py](https://github.com/moderngl/moderngl-window/blob/04112d559f2a3a1092237ecb6961f26f4fd59a11/examples/orbit_camera.py). That example still runs fine.

One question to consider: The dragon mesh I added is 6.8MB. Is it worth decimating it a bit to reduce the filesize?