### PR TITLE
Fix wnd.vsync not exposed

### DIFF
--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -383,6 +383,12 @@ class BaseWindow:
         """bool: vertical sync enabled/disabled"""
         return self._vsync
 
+    @vsync.setter
+    def vsync(self, value: bool):
+        self._set_vsync(value)
+        self._vsync = value
+
+
     @property
     def aspect_ratio(self) -> float:
         """float: The current aspect ratio of the window.
@@ -731,6 +737,13 @@ class BaseWindow:
                 self.name
             )
         )
+
+    def _set_vsync(self, value: bool) -> None:
+        raise NotImplementedError(
+            "Toggling vsync is currently not supported by Window-type: {}".format(
+                self.name
+            )
+        )  
 
     def destroy(self) -> None:
         """

--- a/moderngl_window/context/glfw/window.py
+++ b/moderngl_window/context/glfw/window.py
@@ -123,6 +123,9 @@ class Window(BaseWindow):
             glfw.swap_interval(1)
         else:
             glfw.swap_interval(0)
+    
+    def _set_vsync(self, value: bool) -> None:
+        glfw.swap_interval(value)
 
     @property
     def size(self) -> Tuple[int, int]:


### PR DESCRIPTION
This PR fix address the issue #155 

* added vsync setter to base window
* Implemented newly added _set_vsync function for glfw