### PR TITLE
Fix isinstance moderngl.Context

### DIFF
--- a/moderngl_window/integrations/imgui.py
+++ b/moderngl_window/integrations/imgui.py
@@ -123,7 +123,7 @@ class ModernGLRenderer(BaseOpenGLRenderer):
         if not self.ctx:
             raise ValueError("Missing moderngl context")
 
-        assert isinstance(self.ctx, moderngl.context.Context)
+        assert isinstance(self.ctx, moderngl.Context)
 
         super().__init__()
 


### PR DESCRIPTION
Fixes this issue with the 5.8.0 version of ModernGL when using `moderngl_window.integrations.imgui.ModernglWindowRenderer`

```
assert isinstance(self.ctx, moderngl.context.Context)
AttributeError: module 'moderngl' has no attribute 'context'
```