### PR TITLE
Update program.py

### DIFF
--- a/moderngl_window/opengl/program.py
+++ b/moderngl_window/opengl/program.py
@@ -315,7 +315,7 @@ class ShaderSource:
             for nr, line in enumerate(self._lines):
                 line = line.strip()
                 if line.startswith("#include"):
-                    path = line[9:]
+                    path = re.search(r'#include\s+"?([^"]+)',line)[1]
                     current_id += 1
                     _, source = load_source_func(path)
                     source = ShaderSource(


### PR DESCRIPTION
Better #include handling using regex

This should fix the issue with includes that contain "-escaped strings. Did not test it though.
This should also work: r"#include\s+[",']?([^",']+)"