### PR TITLE
Rename files_dropped function to files_dropped_event.

### DIFF
--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -1122,7 +1122,7 @@ class WindowConfig:
     def close(self):
         """Called when the window is closed"""
 
-    def files_dropped(self, x: int, y: int, paths: List[str]):
+    def files_dropped_event(self, x: int, y: int, paths: List[str]):
         """
         Called when files dropped onto the window
 


### PR DESCRIPTION
Rename files_dropped function to files_dropped_event to fit with the getattr called in assign_event_callbacks.