### PR TITLE
fix windowed pyqt5 window

### DIFF
--- a/moderngl_window/context/pyqt5/window.py
+++ b/moderngl_window/context/pyqt5/window.py
@@ -75,8 +75,8 @@ class Window(BaseWindow):
         # Center the window on the screen if in window mode
         if not self.fullscreen:
             center_window_position = (
-                self.position[0] - self.width / 2,
-                self.position[1] - self.height / 2,
+                self.position[0] - self.width // 2,
+                self.position[1] - self.height // 2,
             )
             self._widget.move(*center_window_position)
 


### PR DESCRIPTION
as arguments to `self._widget.move` must be `int` and not `float` type.

This used to raise:
```
  File "<...>/venv/lib/python3.11/site-packages/moderngl_window/context/pyqt5/window.py", line 81, in __init__
    self._widget.move(*center_window_position)
TypeError: arguments did not match any overloaded call:
  move(self, a0: QPoint): argument 1 has unexpected type 'float'
  move(self, ax: int, ay: int): argument 1 has unexpected type 'float'
```