### PR TITLE
Implement .visible setter and getter for all Window backends

### DIFF
--- a/moderngl_window/__init__.py
+++ b/moderngl_window/__init__.py
@@ -198,6 +198,7 @@ def run_window_config(config_cls: WindowConfig, timer=None, args=None) -> None:
         resizable=values.resizable
         if values.resizable is not None
         else config_cls.resizable,
+        visible=config_cls.visible,
         gl_version=config_cls.gl_version,
         aspect_ratio=config_cls.aspect_ratio,
         vsync=values.vsync if values.vsync is not None else config_cls.vsync,
@@ -270,6 +271,13 @@ def create_parser():
         type=valid_bool,
         default=None,
         help="Enable/disable window resize",
+    )
+    parser.add_argument(
+        "-hd",
+        "--hidden",
+        type=valid_bool,
+        default=False,
+        help="Start the window in hidden mode",
     )
     parser.add_argument(
         "-s",

--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -82,6 +82,7 @@ class BaseWindow:
         gl_version=(3, 3),
         size=(1280, 720),
         resizable=True,
+        visible=True,
         fullscreen=False,
         vsync=True,
         aspect_ratio: float = None,
@@ -97,6 +98,7 @@ class BaseWindow:
             gl_version (tuple): Major and minor version of the opengl context to create
             size (tuple): Window size x, y
             resizable (bool): Should the window be resizable?
+            visible (bool): Should the window be visible when created?
             fullscreen (bool): Open window in fullscreen mode
             vsync (bool): Enable/disable vsync
             aspect_ratio (float): The desired fixed aspect ratio. Can be set to ``None`` to make
@@ -109,6 +111,7 @@ class BaseWindow:
         self._gl_version = gl_version
         self._width, self._height = int(size[0]), int(size[1])
         self._resizable = resizable
+        self._visible = visible
         self._buffer_width, self._buffer_height = size
         self._fullscreen = fullscreen
         self._vsync = vsync
@@ -365,6 +368,32 @@ class BaseWindow:
     @resizable.setter
     def resizable(self, value: bool) -> None:
         self._resizable = value
+
+    @property
+    def visible(self) -> bool:
+        """bool: Window is visible"""
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool) -> None:
+        self._visible = value
+
+    @property
+    def hidden(self) -> bool:
+        """bool: Window is hidden"""
+        return not self._visible
+
+    @hidden.setter
+    def hidden(self, value: bool) -> None:
+        self._visible = not value
+
+    def hide(self) -> None:
+        """Hide the window"""
+        self.visible = False
+
+    def show(self) -> None:
+        """Show the window"""
+        self.visible = True
 
     @property
     def fullscreen(self) -> bool:
@@ -931,6 +960,15 @@ class WindowConfig:
 
         # Default value
         resizable = True
+    """
+    visible = True
+    """
+    Determines if the window should be visible when created
+
+    .. code:: python
+
+        # Default value
+        visible = True
     """
     gl_version = (3, 3)
     """

--- a/moderngl_window/context/glfw/window.py
+++ b/moderngl_window/context/glfw/window.py
@@ -38,6 +38,7 @@ class Window(BaseWindow):
         glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
         glfw.window_hint(glfw.RESIZABLE, self.resizable)
+        glfw.window_hint(glfw.VISIBLE, self.visible)
         glfw.window_hint(glfw.DOUBLEBUFFER, True)
         glfw.window_hint(glfw.DEPTH_BITS, 24)
         glfw.window_hint(glfw.STENCIL_BITS, 8)
@@ -157,6 +158,25 @@ class Window(BaseWindow):
     @position.setter
     def position(self, value: Tuple[int, int]):
         self._position = glfw.set_window_pos(self._window, value[0], value[1])
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            glfw.show_window(self._window)
+        else:
+            glfw.hide_window(self._window)
 
     @property
     def cursor(self) -> bool:

--- a/moderngl_window/context/pygame2/window.py
+++ b/moderngl_window/context/pygame2/window.py
@@ -53,6 +53,9 @@ class Window(BaseWindow):
         if self.resizable:
             self._flags |= pygame.RESIZABLE
 
+        if not self._visible:
+            self._flags |= pygame.HIDDEN
+
         self._set_mode()
         self.title = self._title
         self.cursor = self._cursor
@@ -112,6 +115,25 @@ class Window(BaseWindow):
     @position.setter
     def position(self, value: Tuple[int, int]):
         self._sdl_window.position = value
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            self._sdl_window.show()
+        else:
+            self._sdl_window.hide()
 
     @property
     def cursor(self) -> bool:

--- a/moderngl_window/context/pyglet/window.py
+++ b/moderngl_window/context/pyglet/window.py
@@ -58,6 +58,7 @@ class Window(BaseWindow):
             height=self._height,
             caption=self._title,
             resizable=self._resizable,
+            visible=self._visible,
             vsync=self._vsync,
             fullscreen=self._fullscreen,
             config=config,
@@ -116,6 +117,22 @@ class Window(BaseWindow):
     @position.setter
     def position(self, value: Tuple[int, int]):
         self._window.set_location(value[0], value[1])
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        self._window.set_visible(value)
 
     @property
     def cursor(self) -> bool:

--- a/moderngl_window/context/pyqt5/window.py
+++ b/moderngl_window/context/pyqt5/window.py
@@ -72,11 +72,14 @@ class Window(BaseWindow):
         else:
             self._widget.setFixedSize(self.width, self.height)
 
+        if not self.visible:
+            self._widget.hide()
+
         # Center the window on the screen if in window mode
         if not self.fullscreen:
             center_window_position = (
-                self.position[0] - self.width / 2,
-                self.position[1] - self.height / 2,
+                int(self.position[0] - self.width / 2),
+                int(self.position[1] - self.height / 2),
             )
             self._widget.move(*center_window_position)
 
@@ -154,6 +157,25 @@ class Window(BaseWindow):
     @position.setter
     def position(self, value: Tuple[int, int]):
         self._widget.setGeometry(value[0], value[1], self._width, self._height)
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            self._widget.show()
+        else:
+            self._widget.hide()
 
     def swap_buffers(self) -> None:
         """Swap buffers, set viewport, trigger events and increment frame counter"""

--- a/moderngl_window/context/pyside2/window.py
+++ b/moderngl_window/context/pyside2/window.py
@@ -72,6 +72,9 @@ class Window(BaseWindow):
         else:
             self._widget.setFixedSize(self.width, self.height)
 
+        if not self.visible:
+            self._widget.hide()
+
         # Center the window on the screen if in window mode
         if not self.fullscreen:
             center_window_position = (
@@ -138,6 +141,25 @@ class Window(BaseWindow):
     def size(self, value: Tuple[int, int]):
         pos = self.position
         self._widget.setGeometry(pos[0], pos[1], value[0], value[1])
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            self._widget.show()
+        else:
+            self._widget.hide()
 
     @property
     def position(self) -> Tuple[int, int]:

--- a/moderngl_window/context/sdl2/window.py
+++ b/moderngl_window/context/sdl2/window.py
@@ -57,6 +57,9 @@ class Window(BaseWindow):
             if self.resizable:
                 flags |= sdl2.SDL_WINDOW_RESIZABLE
 
+        if not self._visible:
+            flags |= sdl2.SDL_WINDOW_HIDDEN
+
         self._window = sdl2.SDL_CreateWindow(
             self.title.encode(),
             sdl2.SDL_WINDOWPOS_UNDEFINED,
@@ -124,6 +127,25 @@ class Window(BaseWindow):
     @position.setter
     def position(self, value: Tuple[int, int]):
         sdl2.SDL_SetWindowPosition(self._window, value[0], value[1])
+
+    @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            sdl2.SDL_ShowWindow(self._window)
+        else:
+            sdl2.SDL_HideWindow(self._window)
 
     @property
     def cursor(self) -> bool:

--- a/moderngl_window/context/tk/window.py
+++ b/moderngl_window/context/tk/window.py
@@ -94,6 +94,25 @@ class Window(BaseWindow):
         self._tk.geometry("+{}+{}".format(value[0], value[1]))
 
     @property
+    def visible(self) -> bool:
+        """bool: Is the window visible?
+
+        This property can also be set::
+
+            # Hide or show the window
+            window.visible = False
+        """
+        return self._visible
+
+    @visible.setter
+    def visible(self, value: bool):
+        self._visible = value
+        if value:
+            self._tk.deiconify()
+        else:
+            self._tk.withdraw()
+
+    @property
     def cursor(self) -> bool:
         """bool: Should the mouse cursor be visible inside the window?
 


### PR DESCRIPTION
**Reasoning**

As an alternative<sup>*</sup> to the Headless backend, we can make a window that is hidden on its creation. Adding to this mechanism with hiding/showing it on demand, essentially we have a swappable virtual headless or normal mode.

<sup>* Would likely require video display, but it's ok as alternative</sup>

Transitioning from an initial headless context to a window is tricky when objects are already loaded (Textures, Programs, etc). This allows for a "hidden" creation and optional showcase of the contents

One additional benefit is that, for example, mid way receive an offline render command, then hide the window, revert numbers to the start conditions (controlled by an underlying engine not part of mgl, of course), and proceed normally, without the danger of the user interacting with the window while rendering

**Minimal Example and Code**

> **Implementation sidenote**: It is kind of arbitrary to define a `._visible` or `_hidden` internal flag for tracking on the classes, as either are just the "boolean inverses" of one another. I decide to go with, to what felt to me, most "natural" flag, the `_visible` one, as it would also defaults to True. Nevertheless there are `.hide()`, `.show()` methods and `.hidden` setter and getters that just wraps on the `._visible` attribute of the implementation

Below is a proof of concept code iterating over all backends and changing window visibility on the fly. A commented line is there to create the window as `.visible=False` as an example. I've been using this fork/PR code of mine for a while without issues, though I use GLFW backend and the minimal example is working for me

**Note on PySide2**: Apparently PyQt5 and PySide2 are wrappers around Qt itself, I couldn't import both of those on the same Python process, it gave undefined symbols (could be a Linux thing); but on a practical usage one would chose only one of those, and it's not really a ModernGL's problem here, so the PySide2 backend is commented on the loop below

```python
import math
import moderngl_window
import os

class Window(moderngl_window.WindowConfig):
    gl_version = (3, 3)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)

    def render(self, time, frametime):
        self.ctx.clear(
            (math.sin(time) + 1.0) / 2,
            (math.sin(time + 2) + 1.0) / 2,
            (math.sin(time + 3) + 1.0) / 2,
        )

        if int(time) % 2 == 0:
            if not self.wnd.visible:
                self.wnd.visible = True
                print("Window is now visible")
        else:
            if self.wnd.visible:
                self.wnd.visible = False
                print("Window is now hidden")

        if time > 6:
            self.wnd.close()

for window in ((
    "glfw",
    "pygame2",
    "pyglet",
    "pyqt5",
    # "pyside2",
    "sdl2",
    "tk",
    "headless"
)):
    print(f"\n\n :: Running window class: {window} ::\n\n")
    Window.title = f"Hide and Seek - Backend {window}"
    os.environ["MODERNGL_WINDOW"] = window

    # Start the window hidden
    # Window.visible = False

    moderngl_window.run_window_config(Window)
```

<br>

Bonus small fix of the pyqt5 backend requiring ints 😉