### PR TITLE
Correct typing for TextWriter2d

### DIFF
--- a/moderngl_window/text/bitmapped/text_2d.py
+++ b/moderngl_window/text/bitmapped/text_2d.py
@@ -68,7 +68,7 @@ class TextWriter2D(BaseText):
             )
         )
 
-    def draw(self, pos: tuple[float, float, float], length: int = -1, size: float = 24.0) -> None:
+    def draw(self, pos: tuple[float, float], length: int = -1, size: float = 24.0) -> None:
         assert self.ctx is not None, "There was a problem, we do not have a context"
         assert self.ctx.fbo is not None, "The current context do not have a framebuffer"
         assert self._meta is not None, "We are missing the information needed to write text"


### PR DESCRIPTION
The `pos` argument for Textwriter2d's draw method is annotated as a 3-tuple:
https://github.com/moderngl/moderngl-window/blob/81da3db9092368b1be020b7bde298072d4550799/moderngl_window/text/bitmapped/text_2d.py#L71 

It should be a 2-tuple according to its shader:
https://github.com/moderngl/moderngl-window/blob/81da3db9092368b1be020b7bde298072d4550799/moderngl_window/text/bitmapped/bitmapped/programs/text_2d.glsl#L25
