### PR TITLE
Fix pyglet backend

### DIFF
--- a/moderngl_window/context/pyglet/window.py
+++ b/moderngl_window/context/pyglet/window.py
@@ -51,7 +51,10 @@ class Window(BaseWindow):
         )
 
         if self.fullscreen:
-            display = pyglet.canvas.get_display()
+            if hasattr(pyglet, 'canvas'):
+                display = pyglet.canvas.get_display()
+            else:
+                display = pyglet.display.get_display()
             screen = display.get_default_screen()
             self._width, self._height = screen.width, screen.height
 


### PR DESCRIPTION
The `pyglet.canvas` module has been deprecated, and `pyglet.display` should be used instead:

https://pyglet.readthedocs.io/en/latest/programming_guide/migration.html#canvas-module

The commit uses `hasattr()` for pyglet backwards compatibility.