### PR TITLE
Skip setting window icon on Wayland sessions as it's done via .desktop files

### DIFF
--- a/moderngl_window/context/base/window.py
+++ b/moderngl_window/context/base/window.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import weakref
 from argparse import ArgumentParser, Namespace
@@ -798,6 +799,8 @@ class BaseWindow:
         Args:
             icon_path (str): path to the icon
         """
+        if os.getenv("XDG_SESSION_TYPE") == "wayland":
+            return
         loader = IconLoader(TextureDescription(path=icon_path))
         resolved_path = loader.find_icon()
         self._set_icon(resolved_path)


### PR DESCRIPTION
Minor improvement; Wayland sessions doesn't support setting window icons directly:

- https://github.com/glfw/glfw/issues/2095#issuecomment-1114046553
- https://github.com/slint-ui/slint/issues/6771#issuecomment-2471132612

Detecting a [wayland session](https://askubuntu.com/a/990224) is done via env `XDG_SESSION_TYPE` being `"wayland"`, in which case, we skip the method.

While most window backends should simply ignore trying to set it, I'm getting a huge delay/lag spike in `glfw`, up to half a second of freezing while attempting to set a 512x512 icon as it wraps the image internally "for nothing":

```python
import time
import moderngl_window as mglw

class Test(mglw.WindowConfig):
    gl_version = (3, 3)

    def __init__(self, **kwargs):
        super().__init__(**kwargs)

        start = time.perf_counter()
        self.wnd.set_icon("/home/tremeschin/icon.ico")
        print("Icon set in", time.perf_counter() - start)

    def on_render(self, time: float, frametime: float):
        self.ctx.clear(1.0, 0.0, 0.0, 0.0)

Test.run()
```

```
$ python icon.py --window glfw
INFO - Attempting to load window class: moderngl_window.context.glfw.Window
INFO - ModernGL: 5.12.0
INFO - vendor: NVIDIA Corporation
INFO - renderer: NVIDIA GeForce RTX 3060/PCIe/SSE2
INFO - version: 3.3.0 NVIDIA 570.144
INFO - python: 3.13.3 (main, May 17 2025, 13:49:13) [Clang 20.1.4 ]
INFO - platform: linux
INFO - code: 330
/home/tremeschin/Code/.venv/lib/python3.13/site-packages/glfw/__init__.py:917: 
  GLFWError: (65548) b'Wayland: The platform does not support setting the window icon'
  warnings.warn(message, GLFWError)
Icon set in 0.4196
```

So yea, better save that time lost on blocking code as it hurts primarily glfw, thanks!

